### PR TITLE
Integrate Zenject and refactor to dependency injection

### DIFF
--- a/Assets/Scripts/Gameplay/GameController.cs
+++ b/Assets/Scripts/Gameplay/GameController.cs
@@ -1,5 +1,6 @@
 using Game.Infrastructure;
 using UnityEngine;
+using Zenject;
 
 namespace Game.Gameplay
 {
@@ -8,9 +9,11 @@ namespace Game.Gameplay
     /// </summary>
     public class GameController : MonoBehaviour
     {
+        [Inject] private GameStateMachine _stateMachine;
+
         public void ReturnToMeta()
         {
-            GameBootstrapper.StateMachine.Enter<MetaState>();
+            _stateMachine.Enter<MetaState>();
         }
     }
 }

--- a/Assets/Scripts/Infrastructure/BootstrapState.cs
+++ b/Assets/Scripts/Infrastructure/BootstrapState.cs
@@ -1,3 +1,5 @@
+using Zenject;
+
 namespace Game.Infrastructure
 {
     /// <summary>
@@ -6,12 +8,7 @@ namespace Game.Infrastructure
     /// </summary>
     public class BootstrapState : IState
     {
-        private readonly GameStateMachine _stateMachine;
-
-        public BootstrapState(GameStateMachine stateMachine)
-        {
-            _stateMachine = stateMachine;
-        }
+        [Inject] private GameStateMachine _stateMachine;
 
         public void Enter()
         {

--- a/Assets/Scripts/Infrastructure/GameBootstrapper.cs
+++ b/Assets/Scripts/Infrastructure/GameBootstrapper.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Zenject;
 
 namespace Game.Infrastructure
 {
@@ -8,16 +9,18 @@ namespace Game.Infrastructure
     /// </summary>
     public class GameBootstrapper : MonoBehaviour
     {
-        public static GameStateMachine StateMachine { get; private set; }
+        private GameStateMachine _stateMachine;
+
+        [Inject]
+        public void Construct(GameStateMachine stateMachine)
+        {
+            _stateMachine = stateMachine;
+        }
 
         private void Awake()
         {
-            if (StateMachine == null)
-            {
-                StateMachine = new GameStateMachine(new SceneLoader());
-                DontDestroyOnLoad(this);
-                StateMachine.Enter<BootstrapState>();
-            }
+            DontDestroyOnLoad(this);
+            _stateMachine.Enter<BootstrapState>();
         }
     }
 }

--- a/Assets/Scripts/Infrastructure/GameInstaller.cs
+++ b/Assets/Scripts/Infrastructure/GameInstaller.cs
@@ -1,0 +1,20 @@
+using Zenject;
+
+namespace Game.Infrastructure
+{
+    /// <summary>
+    /// Registers game-level dependencies in the Zenject container.
+    /// </summary>
+    public class GameInstaller : MonoInstaller
+    {
+        public override void InstallBindings()
+        {
+            Container.Bind<SceneLoader>().AsSingle();
+            Container.Bind<GameStateMachine>().AsSingle();
+            Container.Bind<BootstrapState>().AsSingle();
+            Container.Bind<MetaState>().AsSingle();
+            Container.Bind<GameplayState>().AsSingle();
+        }
+    }
+}
+

--- a/Assets/Scripts/Infrastructure/GameStateMachine.cs
+++ b/Assets/Scripts/Infrastructure/GameStateMachine.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Collections.Generic;
+using Zenject;
 
 namespace Game.Infrastructure
 {
@@ -8,30 +7,21 @@ namespace Game.Infrastructure
     /// </summary>
     public class GameStateMachine
     {
-        private readonly Dictionary<Type, IState> _states;
+        private readonly DiContainer _container;
         private IState _activeState;
 
-        public GameStateMachine(SceneLoader sceneLoader)
+        public GameStateMachine(DiContainer container)
         {
-            _states = new Dictionary<Type, IState>
-            {
-                [typeof(BootstrapState)] = new BootstrapState(this),
-                [typeof(MetaState)] = new MetaState(this, sceneLoader),
-                [typeof(GameplayState)] = new GameplayState(this, sceneLoader)
-            };
+            _container = container;
         }
 
         public void Enter<TState>() where TState : class, IState
         {
             _activeState?.Exit();
-            var state = GetState<TState>();
+            var state = _container.Resolve<TState>();
             _activeState = state;
             state.Enter();
         }
-
-        private TState GetState<TState>() where TState : class, IState
-        {
-            return _states[typeof(TState)] as TState;
-        }
     }
 }
+

--- a/Assets/Scripts/Infrastructure/GameplayState.cs
+++ b/Assets/Scripts/Infrastructure/GameplayState.cs
@@ -1,3 +1,5 @@
+using Zenject;
+
 namespace Game.Infrastructure
 {
     /// <summary>
@@ -5,14 +7,7 @@ namespace Game.Infrastructure
     /// </summary>
     public class GameplayState : IState
     {
-        private readonly GameStateMachine _stateMachine;
-        private readonly SceneLoader _sceneLoader;
-
-        public GameplayState(GameStateMachine stateMachine, SceneLoader sceneLoader)
-        {
-            _stateMachine = stateMachine;
-            _sceneLoader = sceneLoader;
-        }
+        [Inject] private SceneLoader _sceneLoader;
 
         public void Enter()
         {

--- a/Assets/Scripts/Infrastructure/MetaState.cs
+++ b/Assets/Scripts/Infrastructure/MetaState.cs
@@ -1,3 +1,5 @@
+using Zenject;
+
 namespace Game.Infrastructure
 {
     /// <summary>
@@ -6,14 +8,7 @@ namespace Game.Infrastructure
     /// </summary>
     public class MetaState : IState
     {
-        private readonly GameStateMachine _stateMachine;
-        private readonly SceneLoader _sceneLoader;
-
-        public MetaState(GameStateMachine stateMachine, SceneLoader sceneLoader)
-        {
-            _stateMachine = stateMachine;
-            _sceneLoader = sceneLoader;
-        }
+        [Inject] private SceneLoader _sceneLoader;
 
         public void Enter()
         {

--- a/Assets/Scripts/Meta/MetaGame.cs
+++ b/Assets/Scripts/Meta/MetaGame.cs
@@ -1,5 +1,6 @@
 using Game.Infrastructure;
 using UnityEngine;
+using Zenject;
 
 namespace Game.Meta
 {
@@ -8,9 +9,11 @@ namespace Game.Meta
     /// </summary>
     public class MetaGame : MonoBehaviour
     {
+        [Inject] private GameStateMachine _stateMachine;
+
         public void StartGameplay()
         {
-            GameBootstrapper.StateMachine.Enter<GameplayState>();
+            _stateMachine.Enter<GameplayState>();
         }
     }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -17,6 +17,7 @@
     "com.unity.timeline": "1.8.7",
     "com.unity.ugui": "2.0.0",
     "com.unity.visualscripting": "1.9.7",
+    "com.svermeulen.zenject": "https://github.com/modesttree/Zenject.git#v9.2.0",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -281,6 +281,12 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.svermeulen.zenject": {
+      "version": "https://github.com/modesttree/Zenject.git#v9.2.0",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {}
+    },
     "com.unity.modules.accessibility": {
       "version": "1.0.0",
       "depth": 0,


### PR DESCRIPTION
## Summary
- add Zenject package and lock entry
- register core services and states via a new Zenject installer
- refactor bootstrapper, states, and controllers to use injected dependencies

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(package not available)*

------
https://chatgpt.com/codex/tasks/task_e_68973fd85f4c8332a220a86a3a7f609d