### PR TITLE
Implement ball combat with saw power-up

### DIFF
--- a/Assets/Scripts/Gameplay/Ball.cs
+++ b/Assets/Scripts/Gameplay/Ball.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+
+namespace Game.Gameplay
+{
+    [RequireComponent(typeof(Rigidbody2D))]
+    public class Ball : MonoBehaviour
+    {
+        [SerializeField] private float _speed = 5f;
+        private Rigidbody2D _rigidbody;
+        private bool _empowered;
+
+        private void Awake()
+        {
+            _rigidbody = GetComponent<Rigidbody2D>();
+        }
+
+        private void Start()
+        {
+            Vector2 direction = Random.insideUnitCircle.normalized;
+            _rigidbody.velocity = direction * _speed;
+        }
+
+        public void SetEmpowered(bool value)
+        {
+            _empowered = value;
+        }
+
+        public void TakeHit()
+        {
+            Debug.Log(name + " was hit");
+        }
+
+        private void OnCollisionEnter2D(Collision2D collision)
+        {
+            Vector2 reflected = Vector2.Reflect(_rigidbody.velocity, collision.contacts[0].normal);
+            _rigidbody.velocity = reflected;
+
+            Ball other = collision.collider.GetComponent<Ball>();
+            if (other != null && _empowered)
+            {
+                other.TakeHit();
+                SawSpawner.Instance.ClearPower();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/SawPowerUp.cs
+++ b/Assets/Scripts/Gameplay/SawPowerUp.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Game.Gameplay
+{
+    public class SawPowerUp : MonoBehaviour
+    {
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            Ball ball = other.GetComponent<Ball>();
+            if (ball != null)
+            {
+                SawSpawner.Instance.Pickup(ball);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/SawSpawner.cs
+++ b/Assets/Scripts/Gameplay/SawSpawner.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using UnityEngine;
+
+namespace Game.Gameplay
+{
+    public class SawSpawner : MonoBehaviour
+    {
+        public static SawSpawner Instance { get; private set; }
+
+        [SerializeField] private GameObject _sawPrefab;
+        [SerializeField] private Vector2 _spawnAreaMin;
+        [SerializeField] private Vector2 _spawnAreaMax;
+
+        private GameObject _currentSaw;
+        private Ball _empoweredBall;
+
+        private void Awake()
+        {
+            Instance = this;
+        }
+
+        private void Start()
+        {
+            SpawnSaw();
+        }
+
+        private void SpawnSaw()
+        {
+            Vector2 position = new Vector2(Random.Range(_spawnAreaMin.x, _spawnAreaMax.x),
+                Random.Range(_spawnAreaMin.y, _spawnAreaMax.y));
+            _currentSaw = Instantiate(_sawPrefab, position, Quaternion.identity);
+        }
+
+        public void Pickup(Ball ball)
+        {
+            if (_empoweredBall != null)
+            {
+                _empoweredBall.SetEmpowered(false);
+            }
+
+            _empoweredBall = ball;
+            _empoweredBall.SetEmpowered(true);
+
+            if (_currentSaw != null)
+            {
+                Destroy(_currentSaw);
+                _currentSaw = null;
+            }
+
+            StartCoroutine(Respawn());
+        }
+
+        private IEnumerator Respawn()
+        {
+            yield return new WaitForSeconds(5f);
+            SpawnSaw();
+        }
+
+        public void ClearPower()
+        {
+            if (_empoweredBall != null)
+            {
+                _empoweredBall.SetEmpowered(false);
+                _empoweredBall = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Ball` script for movement, bouncing, and empowered hits
- Spawn `Saw` power-up that grants empowerment and respawns after 5 seconds
- Power-up transfers between balls and clears after a hit

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689749d2166083328c08197cdbe8f9c7